### PR TITLE
Update CoreVM symbol names.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "picoalloc"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "polkavm-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "picoalloc"
-version = "5.1.0"
+version = "5.2.0"
 edition = "2021"
 authors = ["Jan Bujak <jan@parity.io>"]
 repository = "https://github.com/koute/picoalloc"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -66,7 +66,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "picoalloc"
-version = "5.1.0"
+version = "5.2.0"
 
 [[package]]
 name = "picoalloc-fuzz"

--- a/src/env/corevm.rs
+++ b/src/env/corevm.rs
@@ -3,7 +3,9 @@ use crate::{Env, Size};
 
 #[polkavm_derive::polkavm_import]
 extern "C" {
+    #[polkavm_import(symbol = "corevm_alloc_ext")]
     pub fn alloc(size: u64) -> u64;
+    #[polkavm_import(symbol = "corevm_free_ext")]
     pub fn free(address: u64, size: u64);
 }
 


### PR DESCRIPTION
I've updated CoreVM symbol names in a recent PolkaJAM PR to namespace and wrap them in C programs. This PR updates them in `picoalloc` as well.