### PR TITLE
Fuzz with paranoid disabled too

### DIFF
--- a/ci/jobs/fuzz.sh
+++ b/ci/jobs/fuzz.sh
@@ -13,4 +13,10 @@ echo ">> cargo fuzz run (allocator_buffer)"
 cargo fuzz run allocator_buffer -- -runs=20000
 
 echo ">> cargo fuzz run (allocator_buffer, no realloc_inplace)"
+cargo fuzz run --no-default-features --features paranoid allocator_buffer -- -runs=20000
+
+echo ">> cargo fuzz run (allocator_buffer, no paranoid)"
+cargo fuzz run --no-default-features --features realloc_inplace allocator_buffer -- -runs=20000
+
+echo ">> cargo fuzz run (allocator_buffer, no realloc_inplace, no paranoid)"
 cargo fuzz run --no-default-features allocator_buffer -- -runs=20000

--- a/ci/jobs/fuzz.sh
+++ b/ci/jobs/fuzz.sh
@@ -11,3 +11,6 @@ cargo fuzz run allocator_system -- -runs=20000
 
 echo ">> cargo fuzz run (allocator_buffer)"
 cargo fuzz run allocator_buffer -- -runs=20000
+
+echo ">> cargo fuzz run (allocator_buffer, no realloc_inplace)"
+cargo fuzz run --no-default-features allocator_buffer -- -runs=20000

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,11 +11,15 @@ edition = "2021"
 [package.metadata]
 cargo-fuzz = true
 
+[features]
+default = ["realloc_inplace"]
+realloc_inplace = ["picoalloc/realloc_inplace"]
+
 [dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = "0.4"
 oorandom = "11.1.5"
-picoalloc = { path = "..", features = ["paranoid"] }
+picoalloc = { path = "..", default-features = false, features = ["paranoid"] }
 
 [[bin]]
 name = "allocator_system"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,14 +12,15 @@ edition = "2021"
 cargo-fuzz = true
 
 [features]
-default = ["realloc_inplace"]
+default = ["realloc_inplace", "paranoid"]
 realloc_inplace = ["picoalloc/realloc_inplace"]
+paranoid = ["picoalloc/paranoid"]
 
 [dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = "0.4"
 oorandom = "11.1.5"
-picoalloc = { path = "..", default-features = false, features = ["paranoid"] }
+picoalloc = { path = "..", default-features = false }
 
 [[bin]]
 name = "allocator_system"

--- a/fuzz/fuzz_targets/allocator_buffer.rs
+++ b/fuzz/fuzz_targets/allocator_buffer.rs
@@ -11,6 +11,7 @@ enum Op {
     Free { index: usize },
     Shrink { index: usize, size: u16 },
     Grow { index: usize, size: u16 },
+    Realloc { index: usize, align: u16, size: u16 },
 }
 
 use picoalloc::{Allocator, Env, Size};
@@ -134,6 +135,54 @@ fuzz_target!(|ops: Vec<Op>| {
                 let &(pointer, ref expected_data) = &allocations[index];
                 let slice = unsafe { core::slice::from_raw_parts(pointer.as_ptr(), expected_data.len()) };
                 assert!(slice == expected_data);
+            }
+            Op::Realloc { index, align, size } => {
+                if allocations.is_empty() {
+                    continue;
+                }
+                let align = core::cmp::max(1, (align as usize).next_power_of_two());
+                let size = core::cmp::max(1, size as usize);
+                let index = index % allocations.len();
+
+                let (old_pointer, old_data) = {
+                    let &(pointer, ref expected_data) = &allocations[index];
+                    let slice = unsafe { core::slice::from_raw_parts(pointer.as_ptr(), expected_data.len()) };
+                    assert!(slice == expected_data);
+                    (pointer, expected_data.clone())
+                };
+
+                let Some(new_pointer) = (unsafe {
+                    allocator.realloc(old_pointer, Size::from_bytes_usize(align).unwrap(), Size::from_bytes_usize(size).unwrap())
+                }) else {
+                    continue;
+                };
+
+                assert_eq!(new_pointer.as_ptr().addr() % align, 0);
+
+                if new_pointer != old_pointer {
+                    assert!(alive_addresses.remove(&old_pointer));
+                    assert!(alive_addresses.insert(new_pointer));
+                }
+
+                let usable = unsafe { Allocator::<DefaultEnv>::usable_size(new_pointer) };
+                assert!(usable >= size);
+
+                let preserved = core::cmp::min(old_data.len(), usable);
+                let slice = unsafe { core::slice::from_raw_parts(new_pointer.as_ptr(), preserved) };
+                assert!(slice == &old_data[..preserved]);
+
+                let mut new_data = vec![0u8; usable];
+                new_data[..preserved].copy_from_slice(&old_data[..preserved]);
+                if usable > preserved {
+                    let seed = (new_pointer.as_ptr().addr() ^ 0b11001100) as u128;
+                    fill_slice(seed, &mut new_data[preserved..]);
+                    let tail = unsafe {
+                        core::slice::from_raw_parts_mut(new_pointer.as_ptr().add(preserved), usable - preserved)
+                    };
+                    tail.copy_from_slice(&new_data[preserved..]);
+                }
+
+                allocations[index] = (new_pointer, new_data);
             }
             Op::Grow { index, size } => {
                 let size = size as usize + 1;

--- a/fuzz/fuzz_targets/allocator_buffer.rs
+++ b/fuzz/fuzz_targets/allocator_buffer.rs
@@ -11,7 +11,7 @@ enum Op {
     Free { index: usize },
     Shrink { index: usize, size: u16 },
     Grow { index: usize, size: u16 },
-    Realloc { index: usize, align: u16, size: u16 },
+    Realloc { index: usize, size: u16 },
 }
 
 use picoalloc::{Allocator, Env, Size};
@@ -136,11 +136,10 @@ fuzz_target!(|ops: Vec<Op>| {
                 let slice = unsafe { core::slice::from_raw_parts(pointer.as_ptr(), expected_data.len()) };
                 assert!(slice == expected_data);
             }
-            Op::Realloc { index, align, size } => {
+            Op::Realloc { index, size } => {
                 if allocations.is_empty() {
                     continue;
                 }
-                let align = core::cmp::max(1, (align as usize).next_power_of_two());
                 let size = core::cmp::max(1, size as usize);
                 let index = index % allocations.len();
 
@@ -152,12 +151,10 @@ fuzz_target!(|ops: Vec<Op>| {
                 };
 
                 let Some(new_pointer) = (unsafe {
-                    allocator.realloc(old_pointer, Size::from_bytes_usize(align).unwrap(), Size::from_bytes_usize(size).unwrap())
+                    allocator.realloc(old_pointer, Size::from_bytes_usize(1).unwrap(), Size::from_bytes_usize(size).unwrap())
                 }) else {
                     continue;
                 };
-
-                assert_eq!(new_pointer.as_ptr().addr() % align, 0);
 
                 if new_pointer != old_pointer {
                     assert!(alive_addresses.remove(&old_pointer));


### PR DESCRIPTION
  Follow-up to #5: The paranoid feature through the fuzz crate so CI can exercise both paranoid-on and paranoid-off code paths.